### PR TITLE
Intrepid rather than Interpid

### DIFF
--- a/scripts/Building a space station in Rust.md
+++ b/scripts/Building a space station in Rust.md
@@ -139,7 +139,7 @@ use rand_derive2::RandGen;
 #[derive(Debug, RandGen, Display)]
 enum Name {
    Akira,     Californa, Daedalus,
-   Eisenberg, Interpid,  Miranda,
+   Eisenberg, Intrepid,  Miranda,
    Nova,      Reliant,   Sagan 
 }
 ```


### PR DESCRIPTION
I'm guessing this is a typo. Interestingly, in a real program the compiler would have found this when we tried to use it (unless we continued to typo it).