### PR TITLE
Typo/misspelling on equivalent. It made it into a slide on the video too.

### DIFF
--- a/scripts/02-rust-makes-you-feel-like-a-genius.md
+++ b/scripts/02-rust-makes-you-feel-like-a-genius.md
@@ -551,7 +551,7 @@ pub fn sum_loops(n: i32) -> i32 {
 }
 ```
 
-IS EQUIVILANT TO
+IS equivalent TO
 
 ```rust
 pub fn sum_iterators(n: i32) -> i32 {

--- a/scripts/02-rust-makes-you-feel-like-a-genius.md
+++ b/scripts/02-rust-makes-you-feel-like-a-genius.md
@@ -551,7 +551,7 @@ pub fn sum_loops(n: i32) -> i32 {
 }
 ```
 
-IS equivalent TO
+IS EQUIVALENT TO
 
 ```rust
 pub fn sum_iterators(n: i32) -> i32 {


### PR DESCRIPTION
I also forgot to uppercase it originally, so there's 2 commits.