### PR TITLE
fix typo

### DIFF
--- a/scripts/06-build-your-rust-lightsaber.md
+++ b/scripts/06-build-your-rust-lightsaber.md
@@ -222,7 +222,7 @@ Though we've got very far with astronvim, we're going to take it to the next lev
 ![[neovide.png]]
 
 notes:
-Neovide, a portamentu of Neovim and IDE, provides ligatures and font shaping, an animated cursor, smooth scrolling, animated windows, blurred floating windows, and most importantly, emoji support.
+Neovide, a portmanteau of Neovim and IDE, provides ligatures and font shaping, an animated cursor, smooth scrolling, animated windows, blurred floating windows, and most importantly, emoji support.
 
 It also can connect over a socket to a remote instance of nvim, handy for cloud use
 


### PR DESCRIPTION
From French "porte-manteaux".

https://en.wikipedia.org/wiki/Portmanteau_(disambiguation)

Cheers from a French-speaking reader!