### PR TITLE
Fix titles/subtitles of the Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# NoBoilerplate Discord Code of Conduct
+## NoBoilerplate Discord Code of Conduct
 
 We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 
@@ -38,12 +38,14 @@ The following ideologies or opinions are not welcome.
 
 Talking about them from a outside perspective is allowed, for example discussing how to deal with Homophobic relatives.
 
-### Safe Space
+## Safe Space
 
 This community is explicitly a safe space for the following people:
 - LGBTQIA+
 - neurodivergent (ADHD, Autism, etc.)
 - Plural Systems
+
+## Behaviour
 
 ##### Examples of behavior that contributes to creating a positive environment include:
 
@@ -74,7 +76,7 @@ This community is explicitly a safe space for the following people:
 
 ---
 
-### Moderation Policy
+## Moderation Policy
 
 These are the policies for upholding our community’s rules and the code of conduct. If you want to report a situation that needs to be reviewed by our moderation team, please direct-message the Modmail bot on the NAMTAO Productions Discord.
 


### PR DESCRIPTION
The different levels of titles made some sections subsections of others, in a way which made no sense.